### PR TITLE
Feature/docs/clearer readme md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Request-FP offers two ways to make HTTP requests:
 
 > Most users only need the stateless API. The session API is there for advanced needs—use it when you need more control or state.
 
+> Note: `THttpSession` is an advanced record—call `Session.Init` before using methods like `Session.Get(...)`.
 
 ## Examples
 
@@ -141,11 +142,9 @@ cd tests
 
 ### Test Coverage
 
-- ✅ **23 Tests** covering all HTTP methods and edge cases
-- ✅ **0 Failures** - all tests pass consistently
-- ✅ **0 Memory Leaks** - verified with heap dump analysis
-- ✅ **Cross-Platform** - tested on Windows and Linux
-- ✅ **Network Error Handling** - robust error scenarios
+- ✅ Comprehensive tests for HTTP methods, headers/params, JSON, multipart, and error handling
+- ✅ Cross-platform: Windows and Linux
+- ✅ Memory-safe by construction: advanced records manage lifetimes; JSON parse errors raise `ERequestError`
 
 ## 📚 Documentation
 


### PR DESCRIPTION
## 📋 Description
Refines project positioning and documentation:

- Emphasises “zero‑memory‑leak” and “high‑level API over FPC” value prop.
- Adds a clear note to initialize `THttpSession` with `Session.Init`.

## 🔧 Type of Change

- [x] 📚 Documentation update

## 🚀 Changes Made

- Rewrote “Why Request-FP?” to clarify it’s a thin wrapper over FPC’s HTTP client.
- Updated Features list to match actual API (`Http.*`, `THttpSession`, `TKeyValue`, try-pattern, JSON/multipart).
- Added explicit note: call `Session.Init` before using `THttpSession`.
- Replaced specific testing/coverage/leak claims with accurate, non-assertive wording.

## 🧪 Testing

- [ ] All existing tests pass (`TestRunner.exe -a --format=plain`)
- [ ] Added new tests for new functionality
- [x] Manual review performed
- [ ] No memory leaks detected

Docs-only change. No code paths modified.

**Test Results:**

```bash
# N/A (docs-only)
```

## 🔗 Related Issues

Closes #  (if applicable)

## ✅ Checklist

- [x] My changes generate no new warnings or errors (docs-only)
- [x] I have made corresponding changes to the documentation (README)
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

## 🌐 API Compatibility

- [x] Backward compatible (no breaking changes)

## 📚 Documentation Updates
- [x] README.md updated
- [ ] API documentation updated (`docs/Request.md`)
- [ ] Cheat sheet updated (`docs/Cheat-Sheet.md`)
- [ ] Examples updated (`examples/`)
- [ ] CHANGELOG.md updated

## 🎯 Additional Notes

- The changes aim to improve discoverability (and adoption) by clarifying value over using FPC’s built-in HTTP client directly.
